### PR TITLE
Add traveler login functionality

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -548,6 +548,14 @@
         "postcss-value-parser": "^3.2.3"
       }
     },
+    "axios": {
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.0.tgz",
+      "integrity": "sha512-fmkJBknJKoZwem3/IKSSLpkdNXZeBu5Q7GA/aRsr2btgrptmSCxi2oFjZHqGdK9DoTil9PIHlPIZw2EcRJXRvw==",
+      "requires": {
+        "follow-redirects": "^1.10.0"
+      }
+    },
     "babel-code-frame": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
@@ -4834,8 +4842,7 @@
     "follow-redirects": {
       "version": "1.13.0",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.0.tgz",
-      "integrity": "sha512-aq6gF1BEKje4a9i9+5jimNFIpq4Q1WiwBToeRK5NvZBd/TRsmW8BsJfOEGkr76TbOyPVD3OVDN910EcUNtRYEA==",
-      "dev": true
+      "integrity": "sha512-aq6gF1BEKje4a9i9+5jimNFIpq4Q1WiwBToeRK5NvZBd/TRsmW8BsJfOEGkr76TbOyPVD3OVDN910EcUNtRYEA=="
     },
     "for-in": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "@popperjs/core": "^2.5.3",
+    "axios": "^0.21.0",
     "bootstrap": "^4.5.3",
     "bootstrap-vue": "^2.18.1",
     "jquery": "^3.5.1",

--- a/src/components/Login.vue
+++ b/src/components/Login.vue
@@ -5,21 +5,23 @@
       <div class="input-div">
         <div class="username-div">
           <label for="username">Username:</label>
-          <input type="text" v-model="username" />
+          <input type="text" v-model="loginForm.username" />
         </div>
         <div class="password-div">
           <label for="password">Password:</label>
-          <input type="text" v-model="password" />
+          <input type="text" v-model="loginForm.password" />
         </div>
       </div>
       <div class="login-button-div">
-        <button v-on:click="validForm">login</button>
+        <button v-on:click="validateFormAndUser">login</button>
       </div>
     </div>
-    <template v-if="errors">
+    <template v-if="this.$store.state.errors.length">
       <div class="errors-div">
         <ul>
-          <li v-for="error in errors" v-bind:key="error">- {{ error }}</li>
+          <li v-for="error in this.$store.state.errors" v-bind:key="error">
+            - {{ error }}
+          </li>
         </ul>
       </div>
     </template>
@@ -27,42 +29,36 @@
 </template>
 
 <script>
+import { mapGetters } from 'vuex';
 import agentDashboard from '../pages/agent_dashboard';
+import travelerDashboard from '../pages/traveler_dashboard';
 
 export default {
+  mounted() {
+    this.$store.dispatch('getAllTravelers');
+  },
   data() {
     return {
-      username: '',
-      password: '',
+      loginForm: { username: '', password: '' },
       errors: [],
     };
   },
-  components: { agentDashboard },
+  components: { agentDashboard, travelerDashboard },
   methods: {
-    isValidPassword() {
-      if (this.password === this.$store.state.correctPw) {
-        this.$store.dispatch('validatePassword', this.password);
-        this.determineUser();
-        return true;
-      }
-      return false;
-    },
-    determineUser() {
-      if (this.username === this.$store.state.agentLogin) {
-        this.$store.dispatch('agentLogin', this.username);
+    validateFormAndUser() {
+      this.$store.dispatch('checkForErrors', this.loginForm);
+      this.$store.dispatch('validatePassword', this.loginForm);
+      this.$store.dispatch('validateUsername', this.loginForm);
+      this.$store.dispatch('determineUser', this.loginForm);
+      if (this.whichUser === 'agency') {
+        this.$store.dispatch('agentLogin');
+      } else {
+        this.$store.dispatch('travelerLogin', this.loginForm);
       }
     },
-    validForm() {
-      this.errors = [];
-      if (!this.username === 'agency' || this.username === '') {
-        this.errors.push('Username is required');
-      }
-      if (!this.password === 'travel2020' || this.password === '') {
-        this.errors.push('Password is required');
-      }
-      this.isValidPassword();
-      return true;
-    },
+  },
+  computed: {
+    ...mapGetters(['whichUser']),
   },
 };
 </script>

--- a/src/pages/traveler_dashboard.vue
+++ b/src/pages/traveler_dashboard.vue
@@ -1,0 +1,19 @@
+<template>
+  <div v-if="state.travelerLoggedIn">
+    <h1>Hello, {{ state.traveler.name }}</h1>
+    <h3>You are a {{ state.traveler.travelerType }}</h3>
+    <router-view></router-view>
+  </div>
+</template>
+
+<script>
+export default {
+  data() {
+    return {
+      state: this.$store.state,
+      travId: this.$store.state.travId,
+      travelers: this.$store.state.travelers.travelers,
+    };
+  },
+};
+</script>

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -2,6 +2,7 @@ import Vue from 'vue';
 import Router from 'vue-router';
 // import HelloWorld from '@/components/HelloWorld';
 import AgentDashboard from '../pages/agent_dashboard';
+import TravelerDashboard from '../pages/traveler_dashboard';
 
 Vue.use(Router);
 
@@ -16,6 +17,11 @@ export default new Router({
       path: '/agent-dashboard',
       name: 'AgentDashboard',
       component: AgentDashboard,
+    },
+    {
+      path: '/traveler-dashboard/',
+      name: 'TravelerDashboard',
+      component: TravelerDashboard,
     },
 
   ],

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -1,3 +1,4 @@
+import axios from 'axios';
 import Vue from 'vue';
 import Vuex from 'vuex';
 import router from '../router/index';
@@ -9,36 +10,105 @@ export default new Vuex.Store({
   state: {
     correctPw: 'travel2020',
     agentLogin: 'agency',
-    passwordIsCorrect: false,
+    formData: {},
+    errors: [],
+    formIsValid: false,
+    passwordIsValid: false,
+    usernameIsValid: false,
+    user: '',
     agentLoggedIn: false,
+    travelerLoggedIn: false,
+    travelerId: Number,
+    travelers: [],
+    traveler: {},
   },
 
   getters: {
 
+    whichUser: state => state.user,
+
   },
 
   mutations: {
-    validatePassword(state, password) {
-      if (state.correctPw === password) {
-        state.passwordIsCorrect = true;
-        return;
+    checkForErrors(state, form) {
+      state.errors = [];
+      if (!form.username) {
+        state.errors.push('Username is required.');
       }
-      state.passwordIsCorrect = false;
+      if (!form.password) {
+        state.errors.push('Password is required.');
+      }
+      if (form.username && form.password) {
+        state.formIsValid = true;
+      }
+    },
+    validatePassword(state, form) {
+      if (state.formIsValid && form.password === state.correctPw) {
+        state.passwordIsValid = true;
+      } else {
+        state.errors.push('Please enter a valid password');
+      }
+    },
+    validateUsername(state, form) {
+      if (form.username === state.agentLogin || form.username.includes('traveler')) {
+        state.usernameIsValid = true;
+      } else {
+        state.errors.push('Please enter a valid Username');
+      }
+    },
+    determineUser(state, form) {
+      if (state.formIsValid &&
+        state.passwordIsValid &&
+        state.usernameIsValid) {
+        if (form.username === state.agentLogin) {
+          state.user = form.username;
+        }
+        if (form.username.toLowerCase().includes('traveler') && form.username.slice(8) < state.travelers.length) {
+          state.user = form.username;
+        }
+      }
     },
     agentLogin(state) {
       router.push('/Agent-Dashboard');
       state.agentLoggedIn = true;
-      return true;
     },
+    travelerLogin(state, form) {
+      state.travelerId = form.username.slice(8);
+      state.traveler = this.state.travelers[state.travelerId - 1];
+      state.travelerLoggedIn = true;
+      router.push('/Traveler-Dashboard');
+    },
+    getAllTravelers(state, response) {
+      state.travelers = response.travelers;
+    },
+
   },
 
   actions: {
-    validatePassword(context, password) {
-      context.commit('validatePassword', password);
+    checkForErrors(context, form) {
+      context.commit('checkForErrors', form);
     },
-    agentLogin(context, username) {
-      context.commit('agentLogin', username);
-      return true;
+    validatePassword(context, form) {
+      context.commit('validatePassword', form);
+    },
+    validateUsername(context, form) {
+      context.commit('validateUsername', form);
+    },
+    determineUser(context, form) {
+      context.commit('determineUser', form);
+    },
+
+    agentLogin(context) {
+      context.commit('agentLogin');
+    },
+    travelerLogin(context, form) {
+      context.commit('travelerLogin', form);
+    },
+    getAllTravelers({ commit }) {
+      axios.get('https://fe-apps.herokuapp.com/api/v1/travel-tracker/data/travelers/travelers')
+        .then((response) => {
+          commit('getAllTravelers', response.data);
+        });
     },
 
   },


### PR DESCRIPTION
This commit adds the basic traveler login functionality. When a
traveler logs in they are taken to their specific dashboard page.

## Changes proposed by this PR
closes #3 

## What did you struggle on to complete?
This iteration of the project required me to research getters as well as to reformat the login process as a whole. I saw a few places where mutations were being repeated and I did not like the general flow of the process so I have updated it. Now when logging in the form, username, and password are authenticated before determining where the user should be directed to. At this time if there is a valid login the user is either directed to the agent dashboard page or the traveler dashboard page.

## Checklist:
- [x] code has been linted with ESLint
- [x] I have reviewed my code
- [x] all issue criteria is completed 
- [x] I have fully styled all changes

## Helpful Resources:
[Map getters (I use this to determine if either an agent or traveler is logged in)](https://tenmilesquare.com/understanding-mapgetters-in-vuex/)
[Question on Stack Overflow explaining mutations and why they can't call other mutations](https://stackoverflow.com/questions/44309627/vue-jsvuex-how-to-dispatch-from-a-mutation#:~:text=2%20Answers&text=Mutations%20can't%20dispatch%20further,then%20trigger%20the%20filter%20action.)
