### PR TITLE
Update traveler dashboard

### DIFF
--- a/src/components/MainPageStyling.vue
+++ b/src/components/MainPageStyling.vue
@@ -11,6 +11,9 @@
       >
         <template v-if="index < 15">
           <b-img :src="destination.image" alt="" width="425px" height="350px" />
+          <p>
+            <strong>{{ destination.destination }}</strong>
+          </p>
         </template>
       </div>
     </div>

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -179,10 +179,11 @@ export default new Vuex.Store({
       state.trips.forEach((trip) => {
         const result = isBefore(new Date(trip.date), new Date());
         if (result) {
-          state.travelersPreviousTrips.push(trip);
+          return state.travelersPreviousTrips.push(trip);
         } else if (result === false) {
-          state.travelersUpcomingTrips.push(trip);
+          return state.travelersUpcomingTrips.push(trip);
         }
+        return false;
       });
     },
     calcAmntTravSpent(state) {
@@ -279,10 +280,10 @@ export default new Vuex.Store({
           'https://fe-apps.herokuapp.com/api/v1/travel-tracker/data/trips/trips',
           dataToJson,
         )
-        // eslint-disable-next-line no-console
-        .then((response) => {
+        // eslint-disable-next-line no-shadow
+        .then(({ data }) => {
           // eslint-disable-next-line no-console
-          console.log(response);
+          state.travelersUpcomingTrips.push(data.newResource);
         })
         .catch((e) => {
           // eslint-disable-next-line no-console


### PR DESCRIPTION
This commit updates the functionality on the traveler dashboard page. Now whenever a traveler clicks 'submit' and submits a trip request, the trip is added to the travelers Upcoming Trips array, which then renders it on the page after it is submitted. This way the traveler does not have to log out and back in / refresh in order to see their new trip request.

## Changes proposed by this PR
closes #37 

## What did you struggle on to complete?
I hadn't even thought to simply push the new trip into the travelers upcoming trips array...I was relying on the new trip to be automatically added to it once it was added to the trips Array at the API endpoint. 

## Checklist:
- [x] code has been linted with ESLint
- [x] I have reviewed my code
- [x] all issue criteria is completed 
- [x] I have fully styled all changes