### PR TITLE
Correct bug

### DIFF
--- a/src/pages/traveler_dashboard.vue
+++ b/src/pages/traveler_dashboard.vue
@@ -76,7 +76,7 @@
 
 <script>
 import Vue2Filters from 'vue2-filters';
-// import { mapGetters } from 'vuex';
+import { mapGetters } from 'vuex';
 import Vue from 'vue';
 
 Vue.use(Vue2Filters);
@@ -86,7 +86,8 @@ export default {
       this.$router.push('/');
     }
 
-    if (this.$store.state.tripRequestFormValid === false) {
+    if (this.$store.state.tripRequestFormValid === false &&
+    this.hasTripRequestBeenSubmitted === false) {
       this.$store.dispatch('getTravelersTrips');
       this.$store.dispatch('getTravsTripsAndDestinations');
       this.$store.dispatch('getUpcomingAndPastTrips');
@@ -113,14 +114,7 @@ export default {
       const total = this.$store.state.eachTripsCost.reduce((a, b) => a + b, 0);
       return total;
     },
-    // ...mapGetters(['hasTripRequestBeenSubmitted']),
-    // hopefullyRefresh() {
-    //   if (this.hasTripRequestBeenSubmitted) {
-    //     debugger;
-    //     this.forceRerender();
-    //   }
-    //   return false;
-    // },
+    ...mapGetters(['hasTripRequestBeenSubmitted']),
   },
   methods: {
     forceRerender() {

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -275,7 +275,6 @@ export default new Vuex.Store({
       });
     },
     submitTrip(state) {
-      debugger;
       const data = JSON.stringify({
         id: parseFloat(state.allTrips.length + 1),
         userID: state.traveler.id,
@@ -287,7 +286,6 @@ export default new Vuex.Store({
         suggestedActivities: [''],
       });
       const dataToJson = JSON.parse(data);
-      debugger;
       axios
         .post(
           'https://fe-apps.herokuapp.com/api/v1/travel-tracker/data/trips/trips',
@@ -295,7 +293,6 @@ export default new Vuex.Store({
         )
         // eslint-disable-next-line no-shadow
         .then(({ data }) => {
-          debugger;
           // eslint-disable-next-line no-console
           state.travelersUpcomingTrips.push(data.newResource);
           state.tripRequestSubmitted = true;


### PR DESCRIPTION
This commit addresses the bug that added multiple trips to the travelers dashboard if they did not submit a trip but selected "BACK TO DASHBOARD". Not happening anymore and trips are able to be added on the traveler end and approved / deleted correctly on the agent end. Much success.

## Changes proposed by this PR
closes #87 

## What did you struggle on to complete?
This was happening due to the methods in the mounted hook re-running since I was navigating back to the traveler dashboard. I was able to add a conditional if statement that corrected the issue.

## Checklist:
- [x] code has been linted with ESLint
- [x] I have reviewed my code
- [x] all issue criteria is completed 
- [x] I have fully styled all changes
